### PR TITLE
Raise the bar to only games of 2600's players

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ##  RapidLinkGames Bot
 
-This is bot sends links of top rapid games played on lichess to telegram . It includes games played by players rated from 2500's.
+This is bot sends links of top rapid games played on lichess to telegram . It includes games played by players rated from 2600's.
 The bot monitors their games and sends these games links to a specified Telegram Chat with 
 [@TopRapidBot](https://t.me/TopRapidBot)

--- a/cmd/bot/bot.go
+++ b/cmd/bot/bot.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	start_txt       = "Use this bot to get link of top rated games between players of rating 2500's and above. Type /stop to stop receiving notifications`"
+	start_txt       = "Use this bot to get link of top rated games between players of rating 2600's and above. Type /stop to stop receiving notifications`"
 	stop_txt        = "Sorry to see you leave. Type /start to receive"
 	unknown_cmd     = "I don't know that command"
 	maintenance_txt = "Service will resume shortly"

--- a/poll/poll.go
+++ b/poll/poll.go
@@ -58,7 +58,7 @@ type Member struct {
 }
 
 
-// Poll games after every one minute, filter by rating (>2500), store them if not present in a map  & notify bot users
+// Poll games after every one minute, filter by rating (>2600), store them if not present in a map  & notify bot users
 func (sw *SWbot) PollTopGames() {
 
 	ticker := time.NewTicker(time.Minute * 1)
@@ -80,7 +80,7 @@ func (sw *SWbot) PollTopGames() {
 				w := game.Players.White.Rating
 				b := game.Players.Black.Rating
 
-				if w >= 2500 && b >= 2500 {
+				if w >= 2600 && b >= 2600 {
 					sw.mu.Lock()
 					(*sw.Links)[game.ID] = time.Now()
 					sw.mu.Unlock()


### PR DESCRIPTION
Initially it was games of players rated from 2500, but unfortunately due frequency and numbers of games being many therefore sending frequently notifications which is kind of disturbing, I came with the solution to raise the bar. Only send games of players rated 2600's.